### PR TITLE
support custom primitive types

### DIFF
--- a/src/Fpr/TypeAdapterGlobalSettings.cs
+++ b/src/Fpr/TypeAdapterGlobalSettings.cs
@@ -1,4 +1,7 @@
 ﻿
+using System;
+using System.Collections.Generic;
+
 namespace Fpr
 {
     public class TypeAdapterGlobalSettings
@@ -11,5 +14,6 @@ namespace Fpr
 
         public bool AllowImplicitDestinationInheritance;
 
+        public readonly HashSet<Type> PrimitiveType = new HashSet<Type>(); 
     }
 }

--- a/src/Fpr/Utils/ReflectionUtils.cs
+++ b/src/Fpr/Utils/ReflectionUtils.cs
@@ -86,6 +86,7 @@ namespace Fpr.Utils
                 || type == typeof(Guid)
                 || type.IsEnum
                 || (IsNullable(type) && IsPrimitiveRoot(Nullable.GetUnderlyingType(type)))
+                || TypeAdapterConfig.GlobalSettings.PrimitiveType.Contains(type)
                 || type == typeof(object)
                 ;
         }


### PR DESCRIPTION
Hi,

Thank you for your library. I'm using your library and ran into issue where some classes cannot map. But it should be just copied reference to target.

In my scenario, the class is `DbGeography` which is standard EF type. Even it is class, but it represents primitive type similar to string. 
And every time mapper maps this class, it will throw exception, because this class has no constructor.

The example usage is `TypeAdapterConfig.GlobalSettings.PrimitiveType.Add(typeof (DbGeography));`
