### PR TITLE
change hash key to long

### DIFF
--- a/src/Fpr/Adapters/ClassAdapter.cs
+++ b/src/Fpr/Adapters/ClassAdapter.cs
@@ -19,7 +19,7 @@ namespace Fpr.Adapters
         private static Func<TDestination> _destinationFactory;
         private static AdapterModel<TSource, TDestination> _adapterModel;
 
-        private static readonly int _hashCode = ReflectionUtils.GetHashKey<TSource, TDestination>();
+        private static readonly long _hashCode = ReflectionUtils.GetHashKey<TSource, TDestination>();
 
         private static readonly string _nonInitializedAdapterMessage =
             String.Format("This class adapter was not initialized properly. This typically happens if one of the classes does not have a default (empty) constructor.  SourceType: {0}, DestinationType{1}",
@@ -48,7 +48,7 @@ namespace Fpr.Adapters
         /// <returns>The resulting Destination object.</returns>
         public static TDestination Adapt(TSource source)
         {
-            return Adapt(source, DestinationFactory(), true, true, new Dictionary<int, int>());
+            return Adapt(source, DestinationFactory(), true, true, new Dictionary<long, int>());
         }
 
         /// <summary>
@@ -59,7 +59,7 @@ namespace Fpr.Adapters
         /// <returns>The resulting Destination object.</returns>
         public static TDestination Adapt(TSource source, TDestination destination)
         {
-            return Adapt(source, destination, false, true, new Dictionary<int, int>());
+            return Adapt(source, destination, false, true, new Dictionary<long, int>());
         }
 
         /// <summary>
@@ -69,12 +69,12 @@ namespace Fpr.Adapters
         /// <param name="evaluateMaxDepth">Indicates whether or not max depth should be evaluated.</param>
         /// <param name="parameterIndexes">The parameter indexes.</param>
         /// <returns>The destination object.</returns>
-        public static TDestination Adapt(TSource source, bool evaluateMaxDepth, Dictionary<int, int> parameterIndexes)
+        public static TDestination Adapt(TSource source, bool evaluateMaxDepth, Dictionary<long, int> parameterIndexes)
         {
             return Adapt(source, DestinationFactory(), true, evaluateMaxDepth, parameterIndexes);
         }
 
-        private static TDestination Adapt(TSource source, TDestination destination, bool isNew, bool evaluateMaxDepth, Dictionary<int, int> parameterIndexes)
+        private static TDestination Adapt(TSource source, TDestination destination, bool isNew, bool evaluateMaxDepth, Dictionary<long, int> parameterIndexes)
         {
             if (source == null)
             {
@@ -522,10 +522,10 @@ namespace Fpr.Adapters
         }
 
 
-        private static bool MaxDepthExceeded(ref Dictionary<int, int> parameterIndexes, int maxDepth, bool evaluateMaxDepth)
+        private static bool MaxDepthExceeded(ref Dictionary<long, int> parameterIndexes, int maxDepth, bool evaluateMaxDepth)
         {
             if (parameterIndexes == null)
-                parameterIndexes = new Dictionary<int, int>();
+                parameterIndexes = new Dictionary<long, int>();
 
             if (parameterIndexes.ContainsKey(_hashCode))
             {

--- a/src/Fpr/Adapters/CollectionAdapter.cs
+++ b/src/Fpr/Adapters/CollectionAdapter.cs
@@ -11,27 +11,27 @@ namespace Fpr.Adapters
     {
 
         private static readonly CollectionAdapterModel _collectionAdapterModel = CreateCollectionAdapterModel();
-        private static readonly int _hashCode = ReflectionUtils.GetHashKey<TSourceElement, TDestinationElement>();
+        private static readonly long _hashCode = ReflectionUtils.GetHashKey<TSourceElement, TDestinationElement>();
 
         public static object Adapt(TSource source)
         {
-            return Adapt(source, true, new Dictionary<int, int>());
+            return Adapt(source, true, new Dictionary<long, int>());
         }
 
         public static object Adapt(TSource source, object destination)
         {
-            return Adapt(source, destination, new Dictionary<int, int>());
+            return Adapt(source, destination, new Dictionary<long, int>());
         }
 
-        public static object Adapt(TSource source, bool evaluateMaxDepth, Dictionary<int, int> parameterIndexes)
+        public static object Adapt(TSource source, bool evaluateMaxDepth, Dictionary<long, int> parameterIndexes)
         {
             if (parameterIndexes == null)
-                parameterIndexes = new Dictionary<int, int>();
+                parameterIndexes = new Dictionary<long, int>();
 
             return Adapt(source, null, parameterIndexes);
         }
 
-        public static object Adapt(TSource source, object destination, Dictionary<int, int> parameterIndexes)
+        public static object Adapt(TSource source, object destination, Dictionary<long, int> parameterIndexes)
         {
             if (source == null)
                 return null;
@@ -193,10 +193,10 @@ namespace Fpr.Adapters
             return cam;
         }
 
-        private static bool MaxDepthExceeded(ref Dictionary<int, int> parameterIndexes, int maxDepth, bool evaluateMaxDepth)
+        private static bool MaxDepthExceeded(ref Dictionary<long, int> parameterIndexes, int maxDepth, bool evaluateMaxDepth)
         {
             if (parameterIndexes == null)
-                parameterIndexes = new Dictionary<int, int>();
+                parameterIndexes = new Dictionary<long, int>();
 
             if (parameterIndexes.ContainsKey(_hashCode))
             {

--- a/src/Fpr/ProjectionConfig.cs
+++ b/src/Fpr/ProjectionConfig.cs
@@ -17,7 +17,7 @@ namespace Fpr
 
     internal class ProjectionConfig<TSource, TDestination>
     {
-        private static int _cacheKey = ReflectionUtils.GetHashKey<TSource, TDestination>();
+        private static readonly long _cacheKey = ReflectionUtils.GetHashKey<TSource, TDestination>();
 
         public static ProjectionConfig<TSource, TDestination> NewConfig()
         {

--- a/src/Fpr/TypeAdapter.cs
+++ b/src/Fpr/TypeAdapter.cs
@@ -8,7 +8,7 @@ namespace Fpr
     public static class TypeAdapter
     {
 
-        private static readonly Dictionary<int, FastInvokeHandler> _cache = new Dictionary<int, FastInvokeHandler>();
+        private static readonly Dictionary<long, FastInvokeHandler> _cache = new Dictionary<long, FastInvokeHandler>();
         private static readonly object _cacheLock = new object();
 
         /// <summary>
@@ -85,14 +85,14 @@ namespace Fpr
         {
             FastInvokeHandler adapter;
 
-            if (_cache.TryGetValue(ReflectionUtils.GetHashKey(sourceType, destinationType) + (hasDestination ? 1 : 0), out adapter))
+            if (_cache.TryGetValue(ReflectionUtils.GetHashKey(sourceType, destinationType) * (hasDestination ? -1 : 1), out adapter))
             {
                 return adapter;
             }
 
             lock (_cacheLock)
             {
-                int hashCode = ReflectionUtils.GetHashKey(sourceType, destinationType) + (hasDestination ? 1 : 0);
+                long hashCode = ReflectionUtils.GetHashKey(sourceType, destinationType) * (hasDestination ? -1 : 1);
 
                 if (_cache.TryGetValue(hashCode, out adapter))
                 {

--- a/src/Fpr/TypeAdapterConfig.cs
+++ b/src/Fpr/TypeAdapterConfig.cs
@@ -15,7 +15,7 @@ namespace Fpr
         private static TypeAdapterGlobalSettings _globalSettings = new TypeAdapterGlobalSettings();
 
         private static readonly object _syncLock = new object(); 
-        private static readonly Dictionary<int, object> _configurationCache = new Dictionary<int, object>();
+        private static readonly Dictionary<long, object> _configurationCache = new Dictionary<long, object>();
 
         internal static readonly TypeAdapterConfigSettings ConfigSettings = new TypeAdapterConfigSettings();
 

--- a/src/Fpr/Utils/ProjectionExpression.cs
+++ b/src/Fpr/Utils/ProjectionExpression.cs
@@ -10,9 +10,9 @@ namespace Fpr.Utils
     {
         #region Members
 
-        private static readonly Dictionary<int, Expression> _expressionCache = new Dictionary<int, Expression>();
+        private static readonly Dictionary<long, Expression> _expressionCache = new Dictionary<long, Expression>();
 
-        internal static readonly Dictionary<int, BaseProjectionConfig> ConfigurationCache = new Dictionary<int, BaseProjectionConfig>();
+        internal static readonly Dictionary<long, BaseProjectionConfig> ConfigurationCache = new Dictionary<long, BaseProjectionConfig>();
 
         private readonly IQueryable<TSource> _source;
 
@@ -143,8 +143,7 @@ namespace Fpr.Utils
                     return Expression.Bind(destinationProperty, conditionExpression);
                 }
                 
-                if (sourceProperty.PropertyType.IsGenericType && destPropertyType.IsGenericType &&
-                    destPropertyType != typeof(string) && destPropertyType.GetInterfaces().Any(t => t.Name == "IEnumerable"))
+                if (sourceProperty.PropertyType.IsCollection() && destPropertyType.IsCollection())
                 {
                     var sourceGenericArgument = sourceProperty.PropertyType.GetGenericArguments()[0];
                     var destinationGenericArgument = destPropertyType.GetGenericArguments()[0];

--- a/src/Fpr/Utils/ReflectionUtils.cs
+++ b/src/Fpr/Utils/ReflectionUtils.cs
@@ -7,7 +7,7 @@ using System.Reflection;
 
 namespace Fpr.Utils
 {
-    public static class ReflectionUtils
+    internal static class ReflectionUtils
     {
         private static readonly Type _stringType = typeof(string);
         private static readonly Type _nullableType = typeof (Nullable<>);
@@ -42,30 +42,38 @@ namespace Fpr.Utils
 
         public static Type GetMemberType(this MemberInfo mi)
         {
-            if (mi is PropertyInfo)
+            var pi = mi as PropertyInfo;
+            if (pi != null)
             {
-                return ((PropertyInfo)mi).PropertyType;
+                return pi.PropertyType;
             }
-            if (mi is FieldInfo)
+
+            var fi = mi as FieldInfo;
+            if (fi != null)
             {
-                return ((FieldInfo)mi).FieldType;
+                return fi.FieldType;
             }
-            if (mi is MethodInfo)
+
+            var mti = mi as MethodInfo;
+            if (mti != null)
             {
-                return ((MethodInfo)mi).ReturnType;
+                return mti.ReturnType;
             }
             return null;
         }
 
         public static bool HasPublicSetter(this MemberInfo mi)
         {
-            if (mi is PropertyInfo)
+            var pi = mi as PropertyInfo;
+            if (pi != null)
             {
-                return ((PropertyInfo)mi).GetSetMethod() != null;
+                return pi.GetSetMethod() != null;
             }
-            if (mi is FieldInfo)
+
+            var fi = mi as FieldInfo;
+            if (fi != null)
             {
-                return ((FieldInfo)mi).IsPublic;
+                return fi.IsPublic;
             }
             return false;
         }
@@ -244,7 +252,7 @@ namespace Fpr.Utils
         }
 
 
-        public static Dictionary<int, int> Clone(Dictionary<int, int> values)
+        public static Dictionary<long, int> Clone(Dictionary<long, int> values)
         {
             if (values == null)
                 return null;
@@ -253,14 +261,14 @@ namespace Fpr.Utils
           
         }
 
-        public static int GetHashKey<TSource, TDestination>()
+        public static long GetHashKey<TSource, TDestination>()
         {
-            return (typeof(TSource).GetHashCode() / 2) + typeof(TDestination).GetHashCode();
+            return ((long)typeof(TSource).GetHashCode() << 32) | typeof(TDestination).GetHashCode();
         }
 
-        public static int GetHashKey(Type source, Type destination)
+        public static long GetHashKey(Type source, Type destination)
         {
-            return (source.GetHashCode() / 2) + destination.GetHashCode();
+            return ((long)source.GetHashCode() << 32) | destination.GetHashCode();
         }
 
     }


### PR DESCRIPTION
Hi,

Based on your library, you use `int` as key of record of {TSource + TDestination + has destination flag}. 
Even it is very small chance, but it is possible to have key collision when there are a lot of type mappings.

My solution is using `long`, TSource will use high-order number, TDestination will use low-order number, and destination flag will be positive and negative.

Please review