### PR TITLE
support name with underscore + support ComplexType

### DIFF
--- a/src/Fpr/Fpr.csproj
+++ b/src/Fpr/Fpr.csproj
@@ -37,6 +37,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
+    <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />

--- a/src/Fpr/Utils/ProjectionExpression.cs
+++ b/src/Fpr/Utils/ProjectionExpression.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
+using System.ComponentModel.DataAnnotations.Schema;
 
 namespace Fpr.Utils
 {
@@ -133,6 +134,10 @@ namespace Fpr.Utils
                                         .Where(binding => binding != null);
 
                     var newMemberExpression = Expression.MemberInit(Expression.New(destPropertyType), bindings);
+                    if (sourceProperty.PropertyType.GetCustomAttribute<ComplexTypeAttribute>() != null)
+                    {
+                        return Expression.Bind(destinationProperty, newMemberExpression);
+                    }
 
                     var nullCheck = Expression.Equal(Expression.Property(parameterExpression, sourceProperty), Expression.Constant(null));
 
@@ -179,28 +184,26 @@ namespace Fpr.Utils
 
             if (sourceProperty != null)
             {
-                var sourceChildProperty = sourceProperty.PropertyType.GetProperties().FirstOrDefault(src => src.Name == destinationProperty.Name.Substring(sourceProperty.Name.Length));
+                var sourceChildProperty = sourceProperty.PropertyType.GetProperties().FirstOrDefault(src => src.Name == destinationProperty.Name.Substring(sourceProperty.Name.Length).TrimStart('_'));
 
                 if (sourceChildProperty != null)
                 {
                     Expression childExp = Expression.Property(Expression.Property(parameterExpression, sourceProperty), sourceChildProperty);
 
-                    var nullCheck = Expression.Equal(Expression.Property(parameterExpression, sourceProperty), Expression.Constant(null));
-
                     Type destinationPropertyType = ((PropertyInfo)destinationProperty).PropertyType;
+                    if (sourceChildProperty.PropertyType != destinationPropertyType)
+                        childExp = Expression.Convert(childExp, destinationPropertyType);
+                    if (sourceProperty.PropertyType.GetCustomAttribute<ComplexTypeAttribute>() != null)
+                    {
+                        return Expression.Bind(destinationProperty, childExp);
+                    }
 
-                    bool isNullable = destinationPropertyType.IsGenericType && destinationPropertyType.GetGenericTypeDefinition() == typeof(Nullable<>);
-
+                    var nullCheck = Expression.Equal(Expression.Property(parameterExpression, sourceProperty), Expression.Constant(null));
                     Expression defaultValueExp;
-
-                    if (!isNullable && destinationPropertyType.IsValueType)
+                    if (destinationPropertyType.IsValueType && !destinationPropertyType.IsNullable())
                         defaultValueExp = Expression.Constant(ActivatorExtensions.CreateInstance(destinationPropertyType));
                     else
                         defaultValueExp = Expression.Convert(Expression.Constant(null), destinationPropertyType);
-
-                    if (sourceProperty.PropertyType != destinationPropertyType)
-                        childExp = Expression.Convert(childExp, destinationPropertyType);
-
                     var conditionExpression = Expression.Condition(nullCheck, defaultValueExp, childExp);
 
                     return Expression.Bind(destinationProperty, conditionExpression);

--- a/src/Fpr/Utils/ReflectionUtils.cs
+++ b/src/Fpr/Utils/ReflectionUtils.cs
@@ -15,7 +15,7 @@ namespace Fpr.Utils
         private static readonly Type _iEnumerableType = typeof(IEnumerable);
         private static readonly Type _arrayListType = typeof(ArrayList);
 
-        public static bool IsNullable(Type type)
+        public static bool IsNullable(this Type type)
         {
             return type.IsGenericType && type.GetGenericTypeDefinition() == _nullableType;
         }
@@ -234,7 +234,7 @@ namespace Fpr.Utils
                     && propertyName.StartsWith(property.Name))
                 {
                     invokers.Add(PropertyCaller.CreateGetMethod(property));
-                    GetDeepFlattening(property.PropertyType, propertyName.Substring(property.Name.Length), invokers);
+                    GetDeepFlattening(property.PropertyType, propertyName.Substring(property.Name.Length).TrimStart('_'), invokers);
                 }
                 else if (string.Equals(propertyName, property.Name))
                 {


### PR DESCRIPTION
Hi,

This problem comes around Queryable mapping. For EF, `Complex` type is just group of property, it should never be null.

Currently, when we map `src.ContactInfo.Address` to `dest.ContactInfo_Address`, it will generate `ContactInfo_Address = src.ContactInfo == null ? null : src.ContactInfo.Address`.
When we run this query exception occurred, because EF doesn't know how to map `src.ContactInfo` with `null`.

My solution is just check for `Complex` type, and this will generate `ContactInfo_Address = src.ContactInfo.Address` without null checking.

As part of this PR, I also add support for name with underscore when flattening mapping.
Standard EF, for `Complex` type and also navigation type, by default, it will generate name with underscore (`ContactInfo_Address` for my case).
So this fix it allow `ContactInfo.Address` flatten to `ContactInfo_Address`.

Please review.